### PR TITLE
format text arguments using util.format

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+const format = require('util').format;
 
 let isNodejs = process.version ? true : false;
 
@@ -68,24 +69,24 @@ class Logger {
     this.options = opts;
   }
 
-  debug(text) {
-    this._write(LogLevels.DEBUG, text);
+  debug() {
+    this._write(LogLevels.DEBUG, format.apply(null, arguments));
   }
 
-  log(text) {
-    this.debug(text);
+  log() {
+    this.debug.apply(this, arguments);
   }
 
-  info(text) {
-    this._write(LogLevels.INFO, text);
+  info() {
+    this._write(LogLevels.INFO, format.apply(null, arguments));
   }
 
-  warn(text) {
-    this._write(LogLevels.WARN, text);
+  warn() {
+    this._write(LogLevels.WARN, format.apply(null, arguments));
   }
 
-  error(text) {
-    this._write(LogLevels.ERROR, text);
+  error() {
+    this._write(LogLevels.ERROR, format.apply(null, arguments));
   }
 
   _write(level, text) {

--- a/test/logplease.test.js
+++ b/test/logplease.test.js
@@ -251,6 +251,18 @@ describe('logplease', function() {
       assert.equal(out.split(" ")[2], 'test1234:');
       done();
     });
+
+    it('formats strings using %d, %s', (done) => {
+      let out = '';
+      let old = console.log;
+      console.log = (d) => out += d;
+      const log = Logger.create('test1234', { useColors: false });
+      log.debug('hi %d %s', 314, 'THISISASTRING');
+      console.log = old;
+      let result = out.split(' ').slice(3).join(' ');
+      assert.equal(result, 'hi 314 THISISASTRING');
+      done();
+    });
   });
 
   describe('_write', () => {


### PR DESCRIPTION
Fixes `%s:%s` in orbit.

![screenshot from 2016-05-03 20 02 40](https://cloud.githubusercontent.com/assets/308049/14993210/02b899ac-116a-11e6-907d-876a42a1506d.png)
