### PR TITLE
Module should be the minified ES5 version to be more compatible across use cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "logplease",
   "version": "1.2.14",
   "description": "Simple Javascript logger for Node.js and Browsers",
-  "main": "src/index.js",
+  "main": "dist/logplease.min.js",
   "scripts": {
     "test": "mocha",
     "example": "node example/example.js",


### PR DESCRIPTION
…As it's always best to serve the smallest amount of code in the most usable format (ES5) this should be the distributed file, not the main ES6 source file. This way it minimizes any user cognitive overhead by not requiring any configuration or directory restructuring. https://docs.npmjs.com/files/package.json#main