### PR TITLE
Adding bindings to public methods

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,11 @@ class Logger {
     Object.assign(opts, defaultOptions);
     Object.assign(opts, options);
     this.options = opts;
+    this.debug = this.debug.bind(this);
+    this.log = this.log.bind(this);
+    this.info = this.info.bind(this);
+    this.warn = this.warn.bind(this);
+    this.error = this.error.bind(this);
   }
 
   debug() {


### PR DESCRIPTION
There is a problem where the context of 'this' gets reassigned when used in an object. 
Example: 
const loggerWrapper = {
     info: get(logger,'info',noop)
}

This will throw an error stating that 'this._shouldLog' is not a valid function 