### PR TITLE
Fix locale time test

### DIFF
--- a/test/logplease.test.js
+++ b/test/logplease.test.js
@@ -206,10 +206,8 @@ describe('logplease', function() {
       log.debug("hi")
       console.log = old
       let logArray = out.split(" ")
-      // extra space in local time increases length
-      assert.equal(logArray.length, 5)
-      assert.equal(logArray[4], 'hi')
-      let loggedTime = logArray.slice(0, 2).join(' ').replace('\u001b[37m', '')
+      assert.equal(logArray[logArray.length - 1], 'hi')
+      let loggedTime = logArray.slice(0, logArray.length - 3).join(' ').replace('\u001b[37m', '')
       assert.equal(localTime, loggedTime)
       done()
     })


### PR DESCRIPTION
This PR will fix the locale time test where we checked the array length of the output by removing the output length check.

However, as locale time can be expressed in [various different format](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString), we can't count on the length of the array to be the same for all locales.